### PR TITLE
deps: prefer rustls for web3 dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = { version = "1.0.81" }
 starknet-crypto = { version = "0.5.1" }
 thiserror = { version = "1.0.31" }
-web3 = { version = "0.18.0" }
+web3 = { version = "0.18.0", default-features = false, features = ["http-rustls-tls"] }
 derive_more = {version = "0.99.17"}
 
 [dev-dependencies]


### PR DESCRIPTION
This goes hand-in-hand with https://github.com/dojoengine/dojo/pull/363

This avoids OpenSSL dependency as recommended on the official rust-web3
documentation: https://github.com/tomusdrw/rust-web3#avoiding-openssl-dependency

The main motivation for this is to allow for easier binary distribution with dojoup.