### PR TITLE
deps: prefer rustls for web3 dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = "1.0.81"
 starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", branch = "dev/jsonrpc_0_3_0" }
 thiserror = "1.0.31"
-web3 = "0.18.0"
+web3 = { version = "0.18.0", default-features = false, features = ["http-rustls-tls"] }
 derive_more = "0.99.17"
 
 [dev-dependencies]


### PR DESCRIPTION
Same as https://github.com/dojoengine/starknet-api/pull/1.

For context, the original PR was to avoid OpenSSL:

> This avoids OpenSSL dependency as recommended on the official rust-web3
> documentation: https://github.com/tomusdrw/rust-web3#avoiding-openssl-dependency
> 
> The main motivation for this is to allow for easier binary distribution with dojoup.
> 

But the PR was merged to `main` rather than `dev`, which `dojo` is built on.

> @tarrencev I made an oopsie with this PR, I didn't realize that builds within the dojo repo was using the dev branch instead of the main branch. As a result, the nightly binaries are still broken because of OpenSSL sweat_smile opened https://github.com/dojoengine/starknet-api/pull/2 for this.